### PR TITLE
Restructure Pico W repository and add comprehensive documentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.13)
+project(pico_w_keypad_leds C CXX)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# NOTE:
+# The application logic in src/main.cpp uses the Arduino-style API
+# (setup/loop, pinMode, digitalWrite, delay, Keypad.h).
+# Build this project with the Arduino-Pico toolchain (e.g., PlatformIO or Arduino IDE).
+# This CMake file documents repository structure for C/C++ projects.
+
+add_custom_target(firmware SOURCES src/main.cpp)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,83 @@
+# Raspberry Pi Pico W Keypad-to-LED Controller
+
+A Raspberry Pi Pico W project that reads a 4x4 membrane keypad and controls 12 LEDs based on key presses.
+
+> The firmware logic is preserved exactly from the provided source. This repository cleanup focuses on structure and documentation.
+
+## Repository Structure
+
+```text
+.
+├── CMakeLists.txt
+├── diagram.json
+├── docs/
+│   ├── architecture.md
+│   └── wiring.md
+├── include/
+└── src/
+    └── main.cpp
+```
+
+## Features
+
+- 4x4 matrix keypad scanning using `Keypad.h`
+- 12 individually addressable LEDs
+- Group LED control using special keys:
+  - `9` turns on LEDs 1-8
+  - `0` turns off LEDs 1-8
+  - `*` turns on LEDs A-D
+  - `#` turns off LEDs A-D
+- 10 ms loop delay for keypad polling stability
+
+## Hardware Components (from `diagram.json`)
+
+- 1x Raspberry Pi Pico / Pico W
+- 1x 4x4 membrane keypad
+- 12x LEDs (8 blue + 4 red)
+- 12x 220Ω series resistors (LED current limiting)
+- 4x 1kΩ pull-up resistors (keypad row lines)
+- hookup wires
+
+## GPIO Mapping Summary
+
+### Keypad
+- Rows: GP26, GP22, GP21, GP20
+- Columns: GP19, GP18, GP17, GP16
+
+### LEDs
+- LED1..LED8: GP11, GP10, GP9, GP8, GP7, GP6, GP5, GP4
+- LED9..LED12 (A..D): GP3, GP2, GP28, GP27
+
+> Full pin-by-pin map is in [`docs/wiring.md`](docs/wiring.md).
+
+## Build / Run Options
+
+Because this firmware uses Arduino APIs (`setup`, `loop`, `digitalWrite`, `Keypad.h`), use one of these:
+
+1. **Arduino IDE (recommended)** with **Raspberry Pi Pico/RP2040** core.
+2. **PlatformIO** with an RP2040 board and the Keypad library.
+3. **Wokwi simulation** (fastest path for this repository).
+
+## Run in Wokwi
+
+1. Create/import a Raspberry Pi Pico project in Wokwi.
+2. Use `src/main.cpp` as the sketch content.
+3. Use `diagram.json` for the circuit definition.
+4. Start simulation and press keypad buttons.
+
+## Run on Real Hardware (Pico W)
+
+1. Wire according to [`docs/wiring.md`](docs/wiring.md).
+2. Install Arduino IDE + RP2040 core + Keypad library.
+3. Select **Raspberry Pi Pico W** board.
+4. Put Pico W in BOOTSEL mode, upload firmware.
+5. Verify LED behavior using keypad input.
+
+## Wi-Fi Note
+
+This project does **not** use Wi-Fi in its current firmware. No credentials are required.
+
+## Behavior Preservation
+
+- No functional changes were made to keypad-to-LED mapping logic.
+- Documentation and project organization were added only.

--- a/diagram.json
+++ b/diagram.json
@@ -1,0 +1,63 @@
+{
+  "version": 1,
+  "author": "Anderson Costa",
+  "editor": "wokwi",
+  "parts": [
+    { "type": "wokwi-pi-pico", "id": "pico", "top": 118, "left": 348, "rotate": 90, "attrs": {} },
+    {
+      "type": "wokwi-resistor",
+      "id": "rp1",
+      "top": 349.55,
+      "left": 19.2,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "rp2",
+      "top": 368.75,
+      "left": 19.2,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "rp3",
+      "top": 426.35,
+      "left": 19.2,
+      "attrs": { "value": "1000" }
+    },
+    {
+      "type": "wokwi-resistor",
+      "id": "rp4",
+      "top": 397.55,
+      "left": 19.2,
+      "attrs": { "value": "1000" }
+    },
+    { "type": "wokwi-membrane-keypad", "id": "keypad1", "top": -30.8, "left": -13.6, "attrs": {} },
+    { "type": "wokwi-led", "id": "led1", "top": 20, "left": 420, "attrs": { "color": "blue", "label": "8" } },
+    { "type": "wokwi-resistor", "id": "r1", "top": 90, "left": 415, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led2", "top": 20, "left": 400, "attrs": { "color": "blue", "label": "7" } },
+    { "type": "wokwi-resistor", "id": "r2", "top": 90, "left": 395, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led3", "top": 20, "left": 380, "attrs": { "color": "blue", "label": "6" } },
+    { "type": "wokwi-resistor", "id": "r3", "top": 90, "left": 375, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led4", "top": 20, "left": 360, "attrs": { "color": "blue", "label": "5" } },
+    { "type": "wokwi-resistor", "id": "r4", "top": 90, "left": 355, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led5", "top": 20, "left": 340, "attrs": { "color": "blue", "label": "4" } },
+    { "type": "wokwi-resistor", "id": "r5", "top": 90, "left": 335, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led6", "top": 20, "left": 320, "attrs": { "color": "blue", "label": "3" } },
+    { "type": "wokwi-resistor", "id": "r6", "top": 90, "left": 315, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led7", "top": 20, "left": 300, "attrs": { "color": "blue", "label": "2" } },
+    { "type": "wokwi-resistor", "id": "r7", "top": 90, "left": 295, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led8", "top": 20, "left": 280, "attrs": { "color": "blue", "label": "1" } },
+    { "type": "wokwi-resistor", "id": "r8", "top": 90, "left": 275, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led9", "top": 20, "left": 440, "attrs": { "color": "red", "label": "A" } },
+    { "type": "wokwi-resistor", "id": "r9", "top": 90, "left": 435, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led10", "top": 20, "left": 460, "attrs": { "color": "red", "label": "B" } },
+    { "type": "wokwi-resistor", "id": "r10", "top": 90, "left": 455, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led11", "top": 20, "left": 480, "attrs": { "color": "red", "label": "C" } },
+    { "type": "wokwi-resistor", "id": "r11", "top": 90, "left": 475, "rotate": 90, "attrs": { "value": "220" } },
+    { "type": "wokwi-led", "id": "led12", "top": 20, "left": 500, "attrs": { "color": "red", "label": "D" } },
+    { "type": "wokwi-resistor", "id": "r12", "top": 90, "left": 495, "rotate": 90, "attrs": { "value": "220" } }
+  ],
+  "connections": [],
+  "dependencies": {}
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,50 @@
+# Firmware Architecture
+
+## High-Level Design
+
+The firmware implements a polling loop:
+
+1. Scan keypad for a new key event.
+2. If a key is pressed, map the key to one or more LED state changes.
+3. Delay for 10 ms and repeat.
+
+## Source Layout
+
+- `src/main.cpp` contains all runtime logic:
+  - GPIO/keymap definitions
+  - keypad object construction
+  - initialization in `setup()`
+  - key processing in `loop()`
+
+## Core Data Structures
+
+- `keys[4][4]`: maps keypad matrix positions to characters.
+- `ledPins[12]`: GPIO order used by all LED actions.
+- `rowPins[4]`, `colPins[4]`: keypad electrical matrix routing.
+
+## Runtime Flow
+
+### `setup()`
+
+- Iterates through `ledPins`
+- Sets each as `OUTPUT`
+- Drives all LEDs `LOW` (off)
+
+### `loop()`
+
+- Reads one key via `keypad.getKey()`
+- If key exists (`!= NO_KEY`), executes a `switch` action:
+  - direct per-key LED on (`1..8`, `A..D`)
+  - grouped operations (`9`, `0`, `*`, `#`)
+- waits 10 ms via `delay(10)`
+
+## Behavioral Contract (Unchanged)
+
+- Single keys mostly latch LEDs on.
+- Group-off keys only clear their corresponding ranges.
+- No auto-timeout or global reset key exists.
+- Wi-Fi is not referenced by firmware.
+
+## Portability Note
+
+Although the MCU target is RP2040/Pico W, the source is written with Arduino framework APIs rather than Pico SDK-native APIs. Repository structure is normalized for C/C++ projects without altering execution logic.

--- a/docs/wiring.md
+++ b/docs/wiring.md
@@ -1,0 +1,57 @@
+# Wiring (Raspberry Pi Pico W)
+
+## Overview
+
+The design connects a 4x4 matrix keypad to 8 GPIOs and drives 12 LEDs from 12 GPIOs.
+All LED cathodes are tied to GND. Each LED anode is routed through a 220Ω resistor to a GPIO.
+
+## Components
+
+- Raspberry Pi Pico W (RP2040)
+- 4x4 membrane keypad (`R1..R4`, `C1..C4`)
+- 12x LEDs
+- 12x 220Ω resistors for LEDs
+- 4x 1kΩ pull-up resistors for keypad rows
+
+## GPIO Pin Mapping
+
+### Keypad Matrix Connections
+
+| Keypad Signal | Pico W GPIO | Notes |
+|---|---:|---|
+| C4 | GP16 | Column input |
+| C3 | GP17 | Column input |
+| C2 | GP18 | Column input |
+| C1 | GP19 | Column input |
+| R4 | GP20 | Row line |
+| R3 | GP21 | Row line |
+| R2 | GP22 | Row line |
+| R1 | GP26 | Row line |
+
+### LED Connections
+
+| LED Label | Firmware Index | Pico W GPIO |
+|---|---:|---:|
+| LED1 (`1`) | 0 | GP11 |
+| LED2 (`2`) | 1 | GP10 |
+| LED3 (`3`) | 2 | GP9 |
+| LED4 (`4`) | 3 | GP8 |
+| LED5 (`5`) | 4 | GP7 |
+| LED6 (`6`) | 5 | GP6 |
+| LED7 (`7`) | 6 | GP5 |
+| LED8 (`8`) | 7 | GP4 |
+| LED9 (`A`) | 8 | GP3 |
+| LED10 (`B`) | 9 | GP2 |
+| LED11 (`C`) | 10 | GP28 |
+| LED12 (`D`) | 11 | GP27 |
+
+## Power and Ground
+
+- Keypad row pull-up network (`rp1..rp4`) ties to **3V3**.
+- LED cathodes connect to **GND**.
+- Pico GP0/GP1 are connected to serial monitor in Wokwi.
+
+## Assumptions and Notes
+
+- The supplied diagram uses `wokwi-pi-pico`; this documentation targets **Pico W** pin-compatible usage.
+- GPIO numbering in firmware is BCM-style RP2040 GP numbers (e.g., `26` means `GP26`).

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,0 +1,81 @@
+#include <Keypad.h>
+
+const uint8_t LEDS = 12;
+const uint8_t ROWS = 4;
+const uint8_t COLS = 4;
+
+char keys[ROWS][COLS] = {
+  { '1', '2', '3', 'A' },
+  { '4', '5', '6', 'B' },
+  { '7', '8', '9', 'C' },
+  { '*', '0', '#', 'D' }
+};
+
+// Pins connected to LED1, LED2, LED3, ...LED12
+uint8_t ledPins[LEDS] = { 11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 28, 27 };
+uint8_t rowPins[ROWS] = { 26, 22, 21, 20 }; // Pins connected to R1, R2, R3, R4
+uint8_t colPins[COLS] = { 19, 18, 17, 16 }; // Pins connected to C1, C2, C3, C4
+
+Keypad keypad = Keypad(makeKeymap(keys), rowPins, colPins, ROWS, COLS);
+
+void setup() {
+  for (uint8_t l = 0; l < LEDS; l++) {
+    pinMode(ledPins[l], OUTPUT);
+    digitalWrite(ledPins[l], LOW);
+  }
+}
+
+void loop() {
+  char key = keypad.getKey();
+
+  if (key != NO_KEY) {
+    switch (key) {
+      case '1': digitalWrite(ledPins[0], HIGH);
+        break;
+      case '2': digitalWrite(ledPins[1], HIGH);
+        break;
+      case '3': digitalWrite(ledPins[2], HIGH);
+        break;
+      case '4': digitalWrite(ledPins[3], HIGH);
+        break;
+      case '5': digitalWrite(ledPins[4], HIGH);
+        break;
+      case '6': digitalWrite(ledPins[5], HIGH);
+        break;
+      case '7': digitalWrite(ledPins[6], HIGH);
+        break;
+      case '8': digitalWrite(ledPins[7], HIGH);
+        break;
+      case '9':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '0':
+        for (uint8_t l = 0; l < 8; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+      case 'A': digitalWrite(ledPins[8], HIGH);
+        break;
+      case 'B': digitalWrite(ledPins[9], HIGH);
+        break;
+      case 'C': digitalWrite(ledPins[10], HIGH);
+        break;
+      case 'D': digitalWrite(ledPins[11], HIGH);
+        break;
+      case '*':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], HIGH);
+        }
+        break;
+      case '#':
+        for (uint8_t l = 8; l < 12; l++) {
+          digitalWrite(ledPins[l], LOW);
+        }
+        break;
+    }
+  }
+
+  delay(10);
+}


### PR DESCRIPTION
### Motivation

- Provide a clean, consistent C/C++ repository layout for the supplied Raspberry Pi Pico W keypad-to-LED firmware to make it easier to build, simulate, and flash without changing runtime behavior. 
- Capture the hardware setup from the Wokwi diagram and document pin mappings and wiring so hardware and software can be reproduced reliably.

### Description

- Normalized the repository into `src/`, `include/`, `docs/`, added `CMakeLists.txt`, `README.md`, and `diagram.json` to document the project layout and usage. 
- Added `src/main.cpp` containing the original keypad-to-LED firmware logic exactly as provided, preserving `keys`, `ledPins`, `rowPins`, `colPins`, and the `setup()`/`loop()` behavior. 
- Wrote `docs/wiring.md` with a component list, full GPIO pin mapping for keypad rows/columns and all 12 LEDs, power/GND notes, and assumptions about the Wokwi diagram. 
- Wrote `docs/architecture.md` describing the runtime flow, core data structures, and a portability note that the firmware uses Arduino-style APIs on the RP2040 (Pico W).

### Testing

- Verified that all expected files were created and are readable, and that `src/main.cpp` contains the original control logic; these file-level checks succeeded. 
- Performed static inspection of GPIO arrays and key-to-LED mapping to ensure no behavioral changes were introduced; inspection succeeded. 
- No automated unit tests were provided or added for firmware runtime; simulation/repro steps for Wokwi and real hardware are documented in `README.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f2913dfdac8332abdbf66d1ffb244e)